### PR TITLE
Add entry-mode reading and writing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push, pull_request]
+on: push
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Much better! As it shows, entry-based writing mode is particularly useful when w
 Reading using entry-based mode is a little easier as well:
 
 ```rust
+use tpk::{Element, Reader};
+
 #[inline(always)]
 fn print_string(name: &'static str, element: &Element) {
   match element {

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ At the time of writing, the specification is not finalized, nor is this implemen
 
 ## Usage
 
-At the moment, only manual writing/reading of elements is supported. This means that markers, folders and elements all need to be written and read manually.
+At the moment, only manual writing/reading of elements and entries is supported. This means that most data needs to be written and read manually.
+
+### Element-based writing/reading
 
 For example, to write the TPK equivalent of the following JSON structure:
 
@@ -61,59 +63,58 @@ This looks quite verbose. Reading is even worse:
 ```rust
 use tpk::{Element, Reader};
 
+#[inline(always)]
+fn print_string(name: &'static str, element: Element) {
+  match element {
+    Element::String(string) => println!("The {} is {}", name, string),
+    _ => panic!("Expected string element, got something else"),
+  };
+}
+
+#[inline(always)]
+fn print_uint8(name: &'static str, element: Element) {
+  match element {
+    Element::UInteger8(number) => println!("The {} is {}", name, number),
+    _ => panic!("Expected unsigned integer element, got something else"),
+  };
+}
+
 fn main() {
     // "input" is an already created `Read` implementor
     let mut reader = Reader::new(input);
 
-    // At the moment end of file = syntax error, so let's treat errors as EOF
     let mut in_version = false;
-    while let Ok(element) = reader.read_element() {
+    while let Ok(Some(element)) = reader.read_element() {
         if in_version {
             match element {
                 Element::Marker(name) if name == "name" => {
-                    print_string("version name", reader.read_element().unwrap());
+                    print_string("version name", reader.read_element().unwrap().unwrap());
                 }
                 Element::Marker(name) if name == "major" => {
-                    print_uint8("major version", reader.read_element().unwrap());
+                    print_uint8("major version", reader.read_element().unwrap().unwrap());
                 }
                 Element::Marker(name) if name == "minor" => {
-                    print_uint8("minor version", reader.read_element().unwrap());
+                    print_uint8("minor version", reader.read_element().unwrap().unwrap());
                 }
                 Element::Marker(name) if name == "patch" => {
-                    print_uint8("patch version", reader.read_element().unwrap());
+                    print_uint8("patch version", reader.read_element().unwrap().unwrap());
                 }
                 _ => panic!("Unrecognized entry"),
             }
         } else {
             match element {
                 Element::Marker(name) if name == "format" => {
-                    print_string("format", reader.read_element().unwrap());
+                    print_string("format", reader.read_element().unwrap().unwrap());
                 }
                 Element::Marker(name) if name == "version" => {
                     in_version = true;
                     // Oops, we're not checking that version is a folder!
-                    reader.read_element().unwrap();
+                    reader.read_element().unwrap().unwrap();
                 }
                 _ => panic!("Unrecognized entry"),
             };
         }
     }
-}
-
-#[inline(always)]
-fn print_string(name: &'static str, element: Element) {
-    match element {
-        Element::String(string) => println!("The {} is {}", name, string),
-        _ => panic!("Expected string element, got something else"),
-    };
-}
-
-#[inline(always)]
-fn print_uint8(name: &'static str, element: Element) {
-    match element {
-        Element::UInteger8(number) => println!("The {} is {}", name, number),
-        _ => panic!("Expected unsigned integer element, got something else"),
-    };
 }
 ```
 
@@ -121,7 +122,122 @@ Ouch, that's rough! And we're not even supporting all edge cases... We could eas
 
 This way of writing and reading a file is called "element-mode". This is the lowest-level way of dealing with TPK data and should only be used by tools that need to manipulate raw TPK metadata. This is also the only way supported by `tpk-rust`, for now.
 
-If your need is to casually and easily read and write data to and from TPK files, for example, it is best to wait for the entry-mode, tree-mode or even `serde` support to be implemented.
+If your need is to casually and easily read and write data to and from TPK files, for example, it is best to wait for the tree-mode or even `serde` support to be implemented.
+
+### Entry-based writing/reading
+
+Let's try to write the aforementioned structure as TPK data using entry-based writing:
+
+```rust
+use tpk::{Element, Entry, Writer};
+
+fn main() {
+  // "output" is an already created `Write` implementor
+  let mut writer = Writer::new(file);
+    writer.write_entry(&Entry {
+        name: "format".into(),
+        elements: vec![Element::String("TPK".into())],
+    });
+    writer.write_entry(&Entry {
+        name: "version".into(),
+        elements: vec![Element::Folder],
+    });
+    writer.write_entry(&Entry {
+        name: "name".into(),
+        elements: vec![Element::String("First Development Release".into())],
+    });
+    writer.write_entry(&Entry {
+        name: "major".into(),
+        elements: vec![Element::UInteger8(0)],
+    });
+    writer.write_entry(&Entry {
+        name: "minor".into(),
+        elements: vec![Element::UInteger8(1)],
+    });
+    writer.write_entry(&Entry {
+        name: "patch".into(),
+        elements: vec![Element::UInteger8(0)],
+    });
+}
+```
+
+It's slightly less verbose, but more importantly it is more structure, which allows us to factorize the code a little bit:
+
+```rust
+use tpk::{Element, Entry, Writer};
+
+#[inline(always)]
+fn create_entry(name: &str, element: Element) -> Entry {
+    Entry {
+        name: name.into(),
+        elements: vec![element],
+    }
+}
+
+fn main() {
+    // "output" is an already created `Write` implementor
+    let mut writer = Writer::new(output);
+    writer.write_entry(&create_entry("format", Element::String("TPK".into())));
+    writer.write_entry(&create_entry("version", Element::Folder));
+    writer.write_entry(&create_entry(
+        "name",
+        Element::String("First Development Release".into()),
+    ));
+    writer.write_entry(&create_entry("major", Element::UInteger8(0)));
+    writer.write_entry(&create_entry("minor", Element::UInteger8(1)));
+    writer.write_entry(&create_entry("patch", Element::UInteger8(0)));
+}
+```
+
+Much better! As it shows, entry-based writing mode is particularly useful when we want to operate in a low-level mode, but we don't want to deal with the marker/element association ourselves and the small overhead is acceptable.
+
+Reading using entry-based mode is a little easier as well:
+
+```rust
+#[inline(always)]
+fn print_string(name: &'static str, element: &Element) {
+  match element {
+    Element::String(string) => println!("The {} is {}", name, string),
+    _ => panic!("Expected string element, got something else"),
+  };
+}
+
+#[inline(always)]
+fn print_uint8(name: &'static str, element: &Element) {
+  match element {
+    Element::UInteger8(number) => println!("The {} is {}", name, number),
+    _ => panic!("Expected unsigned integer element, got something else"),
+  };
+}
+
+fn main() {
+  // "input" is an already created `Read` implementor
+  let mut reader = Reader::new(input);
+
+    let mut in_version = false;
+    while let Ok(Some(element)) = reader.read_entry() {
+        if in_version {
+            match element.name.as_str() {
+                "name" => print_string("version name", &element.elements[0]),
+                "major" => print_uint8("major version", &element.elements[0]),
+                "minor" => print_uint8("minor version", &element.elements[0]),
+                "patch" => print_uint8("patch version", &element.elements[0]),
+                _ => panic!("Unrecognized entry"),
+            }
+        } else {
+            match element.name.as_str() {
+                "format" => print_string("format", &element.elements[0]),
+                "version" => {
+                    in_version = true;
+                }
+                _ => panic!("Unrecognized entry"),
+            }
+        }
+    }
+}
+```
+
+Unfortunately, this implementation is just less verbose: we're still not handling some edge cases like `..` or `/*` folders, and we still do not type-check the `version` folder entry.
 
 ## Roadmap
 
@@ -143,7 +259,7 @@ Since `tpk-rust` is planned to be the reference implementation for the TPK data 
   - [ ] Dependency management
   - [ ] Big endianness support
   - [ ] Parser hints (e.g. data size)
-- [ ] Entry-mode reading and writing
+- [x] Entry-mode reading and writing
 - [x] CI/CD
   - [x] CI
   - [x] CD

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ For example, to write the TPK equivalent of the following JSON structure:
 you would need to do the following:
 
 ```rust
-use tpk::{Element, TpkWriter};
+use tpk::{Element, Writer};
 
 fn main() {
     // "output" is an already created `Write` implementor
-    let mut writer = TpkWriter::new(output);
+    let mut writer = Writer::new(output);
     writer.write_element(&Element::Marker("format".into()));
     writer.write_element(&Element::String("TPK".into()));
     writer.write_element(&Element::Marker("version".into()));
@@ -59,11 +59,11 @@ fn main() {
 This looks quite verbose. Reading is even worse:
 
 ```rust
-use tpk::{Element, TpkReader};
+use tpk::{Element, Reader};
 
 fn main() {
     // "input" is an already created `Read` implementor
-    let mut reader = TpkReader::new(input);
+    let mut reader = Reader::new(input);
 
     // At the moment end of file = syntax error, so let's treat errors as EOF
     let mut in_version = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@ mod model;
 pub mod read;
 pub mod write;
 
-pub use model::Element;
+pub use model::{Element, Entry};
 pub use read::Reader;
 pub use write::Writer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,5 @@ pub mod read;
 pub mod write;
 
 pub use model::Element;
-pub use read::TpkReader;
-pub use write::TpkWriter;
+pub use read::Reader;
+pub use write::Writer;

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,6 +38,14 @@ pub enum Element {
     Blob(Vec<u8>),
 }
 
+/// Representation of a TPK entry.
+///
+/// A TPK entry is composed of a name and zero, one or more associated elements.
+pub struct Entry {
+    pub name: String,
+    pub elements: Vec<Element>,
+}
+
 impl Element {
     /// Get the type byte for this [Element].
     pub fn get_type_byte(&self) -> u8 {

--- a/src/read.rs
+++ b/src/read.rs
@@ -67,7 +67,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 ///
 /// This structure holds the source from which TPK data should be read, as well as internal reader
 /// contextual data.
-pub struct TpkReader<T> {
+pub struct Reader<T> {
     read: T,
     previous_bytes_read: usize,
     bytes_read: usize,
@@ -75,13 +75,12 @@ pub struct TpkReader<T> {
 
 const UNEXPECTED_EOF: &str = "expected more, got EOF";
 
-impl<T> TpkReader<T>
-where
-    T: io::Read,
+impl<T> Reader<T>
+    where T: io::Read,
 {
-    /// Create a new [TPK reader][TpkReader].
-    pub fn new(read: T) -> TpkReader<T> {
-        TpkReader {
+    /// Create a new [TPK reader][Reader].
+    pub fn new(read: T) -> Reader<T> {
+        Reader {
             read,
             previous_bytes_read: 0,
             bytes_read: 0,

--- a/src/read.rs
+++ b/src/read.rs
@@ -76,7 +76,8 @@ pub struct Reader<T> {
 const UNEXPECTED_EOF: &str = "expected more, got EOF";
 
 impl<T> Reader<T>
-    where T: io::Read,
+where
+    T: io::Read,
 {
     /// Create a new [TPK reader][Reader].
     pub fn new(read: T) -> Reader<T> {

--- a/src/write.rs
+++ b/src/write.rs
@@ -27,17 +27,16 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// A TPK writer structure.
 ///
 /// This structure holds the destination to which TPK data should be written.
-pub struct TpkWriter<T> {
+pub struct Writer<T> {
     write: T,
 }
 
-impl<T> TpkWriter<T>
-where
-    T: io::Write,
+impl<T> Writer<T>
+    where T: io::Write,
 {
-    /// Create a new [TPK writer][TpkWriter].
-    pub fn new(write: T) -> TpkWriter<T> {
-        TpkWriter { write }
+    /// Create a new [TPK writer][Writer].
+    pub fn new(write: T) -> Writer<T> {
+        Writer { write }
     }
 
     /// Write the given [Element] to this writer.

--- a/src/write.rs
+++ b/src/write.rs
@@ -32,7 +32,8 @@ pub struct Writer<T> {
 }
 
 impl<T> Writer<T>
-    where T: io::Write,
+where
+    T: io::Write,
 {
     /// Create a new [TPK writer][Writer].
     pub fn new(write: T) -> Writer<T> {

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,4 +1,4 @@
-use crate::Element;
+use crate::{Element, Entry};
 use std::{io, mem};
 use thiserror::Error;
 
@@ -44,6 +44,9 @@ where
     ///
     /// This function will write the binary representation of the TPK element, including the type
     /// byte, size bytes and data bytes (if any).
+    ///
+    /// Note that this is a low-level function and, as such, it makes it possible to write
+    /// semantically invalid TPK data, especially while writing [marker elements][Element::Marker].
     pub fn write_element(&mut self, element: &Element) -> Result<()> {
         self.write.write_all(&[element.get_type_byte()])?;
 
@@ -98,6 +101,23 @@ where
             }
             _ => (),
         };
+        Ok(())
+    }
+
+    /// Write the given [Entry] to this writer.
+    ///
+    /// This function will write the binary representation of this entry, by writing a
+    /// [marker element][Element::Marker] containing the name of the entry, as well as every data
+    /// element that this entry contains.
+    ///
+    /// Note that this is a low-level function, and as such, it is possible to write semantically
+    /// invalid TPK data using this function if the entry contains an invalid name.
+    pub fn write_entry(&mut self, entry: &Entry) -> Result<()> {
+        let marker = Element::Marker(entry.name.clone());
+        self.write_element(&marker)?;
+        for element in &entry.elements {
+            self.write_element(element)?;
+        }
         Ok(())
     }
 }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,11 +1,11 @@
 use std::io::Cursor;
 use tpk::read::Error;
-use tpk::{Element, TpkReader};
+use tpk::{Element, Reader};
 
 macro_rules! read_element {
     ($i:ident reads to $p:pat => $e:expr) => {
         let cursor = Cursor::new($i);
-        let mut reader = TpkReader::new(cursor);
+        let mut reader = Reader::new(cursor);
         let result = reader.read_element().unwrap();
         match result {
             $p => $e,
@@ -15,7 +15,7 @@ macro_rules! read_element {
     ($i:ident reads to $p:pat) => {read_element!($i reads to $p => ())};
     ($i:ident fails with $p:pat => $e:expr) => {
         let cursor = Cursor::new($i);
-        let mut reader = TpkReader::new(cursor);
+        let mut reader = Reader::new(cursor);
         let result = reader.read_element();
         match result {
             Err(e) => {

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,9 +1,9 @@
 use std::iter::repeat;
-use tpk::{Element, TpkWriter};
+use tpk::{Element, Writer};
 
 fn assert_element_write(element: Element, expected_size: usize) -> Vec<u8> {
     let mut output = vec![];
-    let mut writer = TpkWriter::new(&mut output);
+    let mut writer = Writer::new(&mut output);
     writer.write_element(&element).unwrap();
     assert_eq!(output.len(), expected_size);
     output
@@ -74,7 +74,7 @@ fn test_write_uint64() {
             0b01011111u8,
             0b11011010u8,
             0b10110100u8,
-            0b00001101u8
+            0b00001101u8,
         ]
     );
 }
@@ -117,7 +117,7 @@ fn test_write_int64() {
             0b10100000u8,
             0b00100101u8,
             0b01001011u8,
-            0b11110010u8
+            0b11110010u8,
         ]
     );
 }
@@ -147,7 +147,7 @@ fn test_write_float64() {
             0b00000100u8,
             0b01001101u8,
             0b00100101u8,
-            0b11000010u8
+            0b11000010u8,
         ]
     );
 }


### PR DESCRIPTION
This pull request adds entry-mode reading and writing to the `tpk` crate.

Additionally, this pull request changes the response type of the `Reader::read_element` function to be `Result<Option<Element>>`, in order to handle end-of-data situations more gracefully.